### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Be sure that you have already registered at the [Dev Portal](https://developer.v
 To initialize the SDK at the __Client Side__ you need only the __Access Token__ created for a client at Dev Portal. The Access Token helps to authenticate client's requests.
 
 ```python
+from virgil_sdk.api import Virgil
 virgil = Virgil("[ACCESS_TOKEN]")
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Be sure that you have already registered at the [Dev Portal](https://developer.v
 To initialize the SDK at the __Client Side__ you need only the __Access Token__ created for a client at Dev Portal. The Access Token helps to authenticate client's requests.
 
 ```python
-from virgil_sdk.api import Virgil
+from virgil_sdk.api import *
 virgil = Virgil("[ACCESS_TOKEN]")
 ```
 


### PR DESCRIPTION
The documentation everywhere was missing what package to import and how to import as `import virgil-sdk ` is not very intuitive. So made the changes to make it easier for Devs to get started with your docs.