### PR TITLE
V5 development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_install: |
 
 install:
   - echo $VIRGIL_APP_KEY_CONTENT_V5 > ~/tests.virgilkey
+  - pip install virgil-crypto
   - pip install .
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,6 @@ setup(
     name="virgil-sdk",
     version="5.0.1",
     packages=find_packages(),
-    install_requires=[
-        'virgil-crypto>3',
-    ],
     package_data={"virgil_sdk": [
         "tests/*",
         "tests/data/*.json"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="virgil-sdk",
-    version="5.0.1",
+    version="5.1.0",
     packages=find_packages(),
     package_data={"virgil_sdk": [
         "tests/*",

--- a/virgil_sdk/cards/card_manager.py
+++ b/virgil_sdk/cards/card_manager.py
@@ -36,7 +36,7 @@ import sys
 
 from virgil_sdk.jwt.token_context import TokenContext
 from virgil_sdk.cards.raw_card_content import RawCardContent
-from virgil_sdk.client import RawSignedModel, UnauthorizedClientException
+from virgil_sdk.client import RawSignedModel, ExpiredAuthorizationClientException
 from virgil_sdk.utils import Utils
 from virgil_sdk.verification import CardVerificationException
 from .card import Card
@@ -271,8 +271,8 @@ class CardManager(object):
         while attempts_number > 0:
             try:
                 result = card_function(card_arg, token)
-            except UnauthorizedClientException as e:
-                token = self._access_token_provider.get_token(context, True)
+            except ExpiredAuthorizationClientException as e:
+                token = self._access_token_provider.get_token(context)
                 if attempts_number-1 < 1:
                     raise e
             attempts_number -= 1

--- a/virgil_sdk/client/card_client.py
+++ b/virgil_sdk/client/card_client.py
@@ -81,12 +81,12 @@ class CardClient(BaseCardClient):
         return RawSignedModel(**response)
 
     def search_card(self, identity, token):
-        # type: (str, str) -> List[RawSignedModel]
+        # type: (Union[str, list], str) -> List[RawSignedModel]
         """
         Searches a cards on Virgil Services by specified identity.
 
         Args:
-            identity: The identity.
+            identity: The identity (or list of identity).
             token: The string representation of Jwt token.
 
         Returns:
@@ -98,9 +98,16 @@ class CardClient(BaseCardClient):
         if not token:
             raise ValueError("Missing JWT token")
 
+        if isinstance(identity, str):
+            request_body = {"identity": identity}
+        elif isinstance(identity, list):
+            request_body = {"identities": identity}
+        else:
+            raise ValueError("Wrong identity(ies) type")
+
         request = Request(
             "/card/v5/actions/search",
-            {"identity": identity},
+            request_body,
             Request.POST,
         )
 

--- a/virgil_sdk/client/card_client.py
+++ b/virgil_sdk/client/card_client.py
@@ -98,7 +98,7 @@ class CardClient(BaseCardClient):
         if not token:
             raise ValueError("Missing JWT token")
 
-        if isinstance(identity, str):
+        if isinstance(identity, str) or Utils.check_unicode(identity):
             request_body = {"identity": identity}
         elif isinstance(identity, list):
             request_body = {"identities": identity}

--- a/virgil_sdk/client/expired_authorization_client_exception.py
+++ b/virgil_sdk/client/expired_authorization_client_exception.py
@@ -31,11 +31,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-
 from .client_exception import ClientException
-from .unauthorized_client_exception import UnauthorizedClientException
-from .expired_authorization_client_exception import ExpiredAuthorizationClientException
-from .raw_signed_model import RawSignedModel
-from .raw_signature import RawSignature
-from .base_card_client import BaseCardClient
-from .card_client import CardClient
+
+
+class ExpiredAuthorizationClientException(ClientException):
+    pass

--- a/virgil_sdk/storage/__init__.py
+++ b/virgil_sdk/storage/__init__.py
@@ -31,5 +31,6 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from .private_key_exporter import PrivateKeyExporter
 from .private_key_storage import PrivateKeyStorage
 from .key_storage import KeyStorage

--- a/virgil_sdk/storage/key_storage.py
+++ b/virgil_sdk/storage/key_storage.py
@@ -43,7 +43,6 @@ class KeyStorage(object):
 
     def __init__(self):
         # type: (...) -> None
-        super(KeyStorage, self).__init__()
         self._key_storage_path = None
 
     @property
@@ -96,7 +95,10 @@ class KeyStorage(object):
         key_file_path = os.path.join(self.__key_storage_path, self.__secure_key_file_name(name))
         if not os.path.exists(key_file_path):
             raise ValueError("Can't load key {}, not found in storage".format(name))
-        return Utils.json_loads(bytes(open(key_file_path, "rb").read()).decode())
+        key_file = open(key_file_path, "rb")
+        key_file_data = key_file.read()
+        key_file.close()
+        return Utils.json_loads(bytes(key_file_data).decode())
 
     def delete(self, name):
         # type: (str) -> None

--- a/virgil_sdk/storage/private_key_exporter.py
+++ b/virgil_sdk/storage/private_key_exporter.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2016-2018 Virgil Security Inc.
+#
+# Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     (1) Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#     (2) Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#     (3) Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+class PrivateKeyExporter(object):
+    """
+    PrivateKeyExporter provides a list of methods that lets user to export and import private key.
+    Args:
+        password: The password for private key.
+    """
+
+    def __init__(
+        self,
+        crypto,
+        password=None  # type: str
+    ):
+        self.crypto = crypto
+        self.__password = password
+
+    def export_private_key(self, private_key):
+        # type: (PrivateKey) -> Union[bytes, bytearray]
+        """
+        Exports the PrivateKey into material representation. If PrivateKeyExporter was
+        instantiated with password then it will be used to export private key.
+        Args:
+            private_key: The private key.
+        Returns:
+            Private key in material representation of bytes.
+        """
+        if self.__password:
+            return self.crypto.export_private_key(private_key, self.__password)
+        else:
+            return self.crypto.export_private_key(private_key)
+
+    def import_private_key(self, key_data):
+        # type: (Union[bytes, bytearray]) -> PrivateKey
+        """
+        Imports the private key from its material representation. If PrivateKeyExporter was
+        instantiated with password then it will be used to import private key.
+        Args:
+            key_data: The private key material representation bytes.
+        Returns:
+            The instance of PrivateKey imported.
+        """
+        if self.__password:
+            return self.crypto.import_private_key(key_data, self.__password)
+        else:
+            return self.crypto.import_private_key(key_data)

--- a/virgil_sdk/storage/private_key_storage.py
+++ b/virgil_sdk/storage/private_key_storage.py
@@ -31,14 +31,13 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from virgil_crypto import PrivateKeyExporter
 from virgil_sdk.storage.key_storage import KeyStorage
 from virgil_sdk.storage.key_entry import KeyEntry
 
 
 class PrivateKeyStorage(object):
 
-    def __init__(self, key_storage=KeyStorage(), key_exporter=PrivateKeyExporter()):
+    def __init__(self, key_exporter, key_storage=KeyStorage()):
         self.key_storage = key_storage
         self.__key_exporter = key_exporter
 
@@ -54,7 +53,7 @@ class PrivateKeyStorage(object):
         """
         if not name:
             raise ValueError("No name provided for store.")
-        if not  private_key:
+        if not private_key:
             raise ValueError("No key provided for store.")
         exported_key_data = self.__key_exporter.export_private_key(private_key)
         key_entry = KeyEntry(name, exported_key_data, meta)

--- a/virgil_sdk/tests/cards/card_manager_test.py
+++ b/virgil_sdk/tests/cards/card_manager_test.py
@@ -42,7 +42,7 @@ from virgil_crypto.card_crypto import CardCrypto
 from virgil_sdk.tests import config
 from virgil_sdk.tests.base_test import BaseTest
 from virgil_sdk.cards import RawCardContent
-from virgil_sdk.client import RawSignedModel, ClientException
+from virgil_sdk.client import RawSignedModel, ClientException, ExpiredAuthorizationClientException
 from virgil_sdk import CardManager, VirgilCardVerifier
 from virgil_sdk.jwt import JwtGenerator
 from virgil_sdk.signers import ModelSigner
@@ -232,7 +232,7 @@ class CardManagerTest(BaseTest):
         access_token_provider = self.FakeTokenProvider(token_generator)
         card_manager = self._data_generator.generate_card_manager(access_token_provider)
         self.assertRaises(
-            ClientException,
+            ExpiredAuthorizationClientException,
             card_manager.get_card,
             self._data_generator.generate_card_id()
         )

--- a/virgil_sdk/tests/storage/private_key_storage_test.py
+++ b/virgil_sdk/tests/storage/private_key_storage_test.py
@@ -35,6 +35,7 @@ import binascii
 import hashlib
 import os
 
+from virgil_sdk.storage import PrivateKeyExporter
 from virgil_sdk.storage import PrivateKeyStorage
 from virgil_sdk.tests import BaseTest
 
@@ -44,7 +45,8 @@ class PrivateKeyStorageTest(BaseTest):
     def test_store(self):
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         private_key_storage.store(key_pair.private_key, key_name)
         try:
             self.assertTrue(os.path.exists(self.__filename_for_clean(private_key_storage, key_name)))
@@ -53,19 +55,22 @@ class PrivateKeyStorageTest(BaseTest):
 
     def test_store_empty_name(self):
         key_pair = self._crypto.generate_keys()
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.store, key_pair.private_key, None)
 
     def test_store_empty_key(self):
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.store, None, key_name)
 
     def test_load(self):
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
         additional_data = {"some_key": "some_val"}
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         private_key_storage.store(key_pair.private_key, key_name, additional_data)
         loaded_key, loaded_meta = private_key_storage.load(key_name)
         try:
@@ -76,13 +81,15 @@ class PrivateKeyStorageTest(BaseTest):
 
     def test_load_unexisting_key(self):
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(10)).decode()))
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.load, key_name)
 
     def test_delete(self):
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         private_key_storage.store(key_pair.private_key, key_name)
         try:
             private_key_storage.delete(key_name)
@@ -93,11 +100,13 @@ class PrivateKeyStorageTest(BaseTest):
 
     def test_delete_unexisting_key(self):
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(10)).decode()))
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.delete, key_name)
 
     def test_delete_empty_name(self):
-        private_key_storage = PrivateKeyStorage()
+        private_key_exporter = PrivateKeyExporter(self._crypto)
+        private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.delete, None)
 
     def __filename_for_clean(self, private_key_storage, key_name):


### PR DESCRIPTION

Added multiply identity search
Added tests for multiply identity search
Added private key exporter to backward compatibility
Added handling of expired authorization tokens (now retries will be regenerate token only if token expired)
Added slowed card manager to test, for fix expired token test 

Removed virgil_crypto dependency for PrivateKeyStorage

Fixed weak warning in key storage test
Fixed CardClient tests for use cards url from config
Fix bug with unicode string at python2.7 version