### PR TITLE
Fix card creation from snapshot

### DIFF
--- a/virgil_sdk/cards/card.py
+++ b/virgil_sdk/cards/card.py
@@ -105,7 +105,7 @@ class Card(object):
             card_content._previous_card_id = loaded_snapshot["previous_card_id"]
         else:
             card_content._previous_card_id = None
-        card_content._content_snapshot = None
+        card_content._content_snapshot = content_snapshot
         return card_content
 
     @classmethod
@@ -131,7 +131,14 @@ class Card(object):
         if raw_singed_model.signatures:
             for sign in raw_singed_model.signatures:
                 if isinstance(sign, dict):
-                    card_signature = CardSignature(**sign)
+                    if "snapshot" in sign.keys():
+                        card_signature = CardSignature(
+                            sign["signer"],
+                            bytearray(Utils.b64decode(sign["signature"])),
+                            sign["snapshot"]
+                        )
+                    else:
+                        card_signature = CardSignature(sign["signer"], bytearray(Utils.b64decode(sign["signature"])))
                     signatures.append(card_signature)
                 if isinstance(sign, CardSignature):
                     card_signature = sign

--- a/virgil_sdk/cards/card_manager.py
+++ b/virgil_sdk/cards/card_manager.py
@@ -169,7 +169,8 @@ class CardManager(object):
         else:
             if any(list(map(lambda x: x.identity != identity, cards))):
                 raise CardVerificationException("Invalid cards")
-        map(lambda x: self.__validate(x), cards)
+        for card in cards:
+            self.__validate(card)
         return self._linked_card_list(cards)
 
     def import_card(self, card_to_import):
@@ -247,6 +248,8 @@ class CardManager(object):
 
     def __publish_raw_card(self, raw_card):
         # type: (RawSignedModel) -> Card
+        if self._sign_callback:
+            self._sign_callback(raw_card)
         card_content = RawCardContent.from_signed_model(self._card_crypto, raw_card)
         token_context = TokenContext(card_content.identity, "publish_card")
         token = self._access_token_provider.get_token(token_context)

--- a/virgil_sdk/cards/card_signature.py
+++ b/virgil_sdk/cards/card_signature.py
@@ -65,6 +65,7 @@ class CardSignature(object):
         }
         if self.snapshot:
             res["snapshot"] = Utils.b64encode(self.snapshot)
+        return res
 
     @property
     def signer(self):

--- a/virgil_sdk/cards/raw_card_content.py
+++ b/virgil_sdk/cards/raw_card_content.py
@@ -47,7 +47,7 @@ class RawCardContent(object):
         public_key,  # type: PublicKey
         created_at,  # type datetime
         version="5.0",  # type: str
-        previous_card_id=None  # type: str
+        previous_card_id=None,  # type: str
     ):
         self._identity = identity
         self._public_key = public_key
@@ -94,7 +94,7 @@ class RawCardContent(object):
             card_content._previous_card_id = loaded_snapshot["previous_card_id"]
         else:
             card_content._previous_card_id = None
-        card_content._content_snapshot = None
+        card_content._content_snapshot = content_snapshot
         return card_content
 
     @classmethod

--- a/virgil_sdk/jwt/jwt.py
+++ b/virgil_sdk/jwt/jwt.py
@@ -123,7 +123,7 @@ class Jwt(AccessToken):
         Whether or not token is expired.
         """
         if not expiration_timestamp:
-            expiration_time = datetime.datetime.now()
+            expiration_time = datetime.datetime.utcnow()
         else:
             expiration_time = datetime.datetime.utcfromtimestamp(expiration_timestamp)
         return expiration_time >= self._body_content.expires_at
@@ -136,6 +136,16 @@ class Jwt(AccessToken):
         base64UrlEncode(JWT Header) + "." + base64UrlEncode(JWT Body)
         """
         return self._unsigned_data
+
+    @property
+    def header_content(self):
+        """Gets representation of jwt header"""
+        return self._header_content
+
+    @property
+    def body_content(self):
+        """Gets representation of jwt body"""
+        return self._body_content
 
     @property
     def signature_data(self):

--- a/virgil_sdk/jwt/jwt_body_content.py
+++ b/virgil_sdk/jwt/jwt_body_content.py
@@ -77,7 +77,7 @@ class JwtBodyContent(object):
         body_content = cls.__new__(cls)
         body_content._issued_at = datetime.datetime.utcfromtimestamp(json_loaded_dict["iat"])
         body_content._expires_at = datetime.datetime.utcfromtimestamp(json_loaded_dict["exp"])
-        body_content._additional_data = json_loaded_dict["ada"]
+        body_content._additional_data = json_loaded_dict["ada"] if "ada" in json_loaded_dict.keys() else {}
         body_content._issuer = json_loaded_dict["iss"]
         body_content.subject = json_loaded_dict["sub"]
         return body_content
@@ -112,11 +112,34 @@ class JwtBodyContent(object):
         return self._issuer
 
     @property
+    def issued_at(self):
+        """Jwt issued at"""
+        return self._issued_at
+
+    @property
+    def issued_at_timestamp(self):
+        return Utils.to_timestamp(self._issued_at)
+
+    @property
     def expires_at(self):
         """When jwt expire."""
         return self._expires_at
 
     @property
+    def expires_at_timestamp(self):
+        return Utils.to_timestamp(self.expires_at)
+
+    @property
     def identity(self):
         """Jwt identity."""
         return self._identity
+
+    @property
+    def app_id(self):
+        """Jwt application id"""
+        return self._app_id
+
+    @property
+    def additional_data(self):
+        """Jwt additional data"""
+        return self._additional_data

--- a/virgil_sdk/jwt/jwt_generator.py
+++ b/virgil_sdk/jwt/jwt_generator.py
@@ -78,6 +78,8 @@ class JwtGenerator(object):
         Returns:
             A new instance of Jwt.
         """
+        if data is not None and not isinstance(data, dict):
+            raise TypeError("Wrong type of additional data, it must be dict")
         issued_at = datetime.datetime.utcnow()
         expires_at = datetime.datetime.utcfromtimestamp(Utils.to_timestamp(issued_at) + self._lifetime)
         jwt_body = JwtBodyContent(

--- a/virgil_sdk/jwt/providers/caching_callback_provider.py
+++ b/virgil_sdk/jwt/providers/caching_callback_provider.py
@@ -48,11 +48,12 @@ class CachingCallbackProvider(AccessTokenProvider):
     def __init__(
         self,
         renew_jwt_callback,  # type: function
-        token_ttl=TOKEN_TTL  # type: int
+        token_ttl=TOKEN_TTL,  # type: int
+        initial_token=None  # type Jwt
     ):
         self._token_ttl = token_ttl
         self.__renew_jwt_callback = partial(renew_jwt_callback, token_ttl=token_ttl)
-        self.__access_token = None
+        self.__access_token = initial_token
 
     def get_token(self, token_context):
         # type: (TokenContext) -> Jwt

--- a/virgil_sdk/tests/cards/card_manager_test.py
+++ b/virgil_sdk/tests/cards/card_manager_test.py
@@ -35,11 +35,13 @@ import binascii
 import datetime
 import os
 import uuid
+from base64 import b64decode
 from time import sleep
 
 from virgil_crypto.access_token_signer import AccessTokenSigner
 from virgil_crypto.card_crypto import CardCrypto
 
+from virgil_sdk.jwt.providers import CallbackJwtProvider, CachingCallbackProvider
 from virgil_sdk.tests import config
 from virgil_sdk.tests.base_test import BaseTest
 from virgil_sdk.cards import RawCardContent, Card
@@ -107,14 +109,111 @@ class CardManagerTest(BaseTest):
         def get_token(self, token_context):
             return self._token
 
+    class PositiveVerifier(object):
+
+        @staticmethod
+        def verify_card(card):
+            return True
+
     class NegativeVerifier(object):
 
         @staticmethod
         def verify_card(card):
             return False
 
+    def test_negative_verify(self):
+        # STC-13
+        key_pair = self._crypto.generate_keys()
+        manager = CardManager(
+            CardCrypto(),
+            api_url=config.VIRGIL_API_URL,
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            sign_callback=self.sign_callback,
+            card_verifier=self.NegativeVerifier()
+        )
+
+        self.assertRaises(
+            CardVerificationException,
+            manager.import_card,
+            self._compatibility_data["STC-3.as_string"]
+        )
+        self.assertRaises(
+            CardVerificationException,
+            manager.import_card,
+            self._compatibility_data["STC-3.as_json"]
+        )
+        self.assertRaises(
+            CardVerificationException,
+            manager.publish_card,
+            key_pair.private_key,
+            key_pair.public_key,
+            "alice-" + str(uuid.uuid4())
+        )
+        self.assertRaises(
+            CardVerificationException,
+            manager.publish_card,
+            self._data_generator.generate_raw_signed_model(key_pair, True)
+        )
+        self.assertRaises(
+            CardVerificationException,
+            manager.get_card,
+            "f80dc44398c33bf7abc9c4aba19d9358923f9217c7704695fce4857af0775a87"
+        )
+        self.assertRaises(
+            CardVerificationException,
+            manager.search_card,
+            "alice-dc3dc4a7-dfbf-42ea-b89f-9c4062ee4e3d"
+        )
+
     def test_create_card_register_new_card_on_service(self):
-        card = self.publish_card("alice-" + str(uuid.uuid4()))
+        # STC-17
+        key_pair = self._crypto.generate_keys()
+
+        validator = VirgilCardVerifier(CardCrypto())
+        if config.VIRGIL_CARD_SERVICE_PUBLIC_KEY:
+            validator._VirgilCardVerifier__virgil_public_key_base64 = config.VIRGIL_CARD_SERVICE_PUBLIC_KEY
+
+        manager = CardManager(
+            CardCrypto(),
+            api_url=config.VIRGIL_API_URL,
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            sign_callback=self.sign_callback,
+            card_verifier=validator,
+        )
+
+        card = manager.publish_card(
+            identity="alice-" + str(uuid.uuid4()),
+            public_key=key_pair.public_key,
+            private_key=key_pair.private_key,
+        )
+        self.assertIsNotNone(card)
+        got_card = self.get_card(card.id)
+        self.assertEqual(card.content_snapshot, got_card.content_snapshot)
+        self.assertEqual(card.signatures[0].signer, ModelSigner.SELF_SIGNER)
+        self.assertEqual(got_card.signatures[0].signer, ModelSigner.SELF_SIGNER)
+        self.assertFalse(got_card.is_outdated)
+        self.assertEqual(len(got_card.signatures), 2)
+
+    def test_create_card_register_new_card_on_service_with_meta(self):
+        # STC-18
+        key_pair = self._crypto.generate_keys()
+
+        provider = CachingCallbackProvider(self._get_token_from_server, 10)
+        validator = VirgilCardVerifier(CardCrypto())
+
+        card_manager = CardManager(
+            CardCrypto(),
+            access_token_provider=provider,
+            card_verifier=validator
+        )
+        card = card_manager.publish_card(
+            identity="alice-" + str(uuid.uuid4()),
+            public_key=key_pair.public_key,
+            private_key=key_pair.private_key,
+            extra_fields={
+                "some_meta_key": "some_meta_val"
+            }
+        )
         self.assertIsNotNone(card)
         got_card = self.get_card(card.id)
         self.assertEqual(card.content_snapshot, got_card.content_snapshot)
@@ -123,12 +222,14 @@ class CardManagerTest(BaseTest):
         self.assertEqual(len(got_card.signatures), 2)
 
     def test_create_card_with_previous_card_id_register_new_card_with_previous_card_id(self):
+        # STC-19
         alice_name = "alice-" + str(uuid.uuid4())
         alica_card = self.publish_card(alice_name)
         new_alice_card = self.publish_card(alice_name, alica_card.id)
         self.assertEqual(new_alice_card.previous_card_id, alica_card.id)
 
     def test_previous_card_id_outdated(self):
+        # STC-19
         alice_name = "alice-" + str(uuid.uuid4())
         alica_card = self.publish_card(alice_name)
         new_alice_card = self.publish_card(alice_name, alica_card.id)
@@ -136,6 +237,7 @@ class CardManagerTest(BaseTest):
         self.assertTrue(outdated_card.is_outdated)
 
     def test_search_card_by_identity_with_two_related_cards_return_one_actual_cards(self):
+        # STC-20
         alice_name = "alice-" + str(uuid.uuid4())
         alice_card = self.publish_card(alice_name)
         new_alice_card = self.publish_card(alice_name, alice_card.id)
@@ -145,6 +247,34 @@ class CardManagerTest(BaseTest):
         self.assertEqual(actual_card.id, new_alice_card.id)
         self.assertEqual(actual_card.previous_card_id, alice_card.id)
         self.assertTrue(actual_card.previous_card.is_outdated)
+
+    def test_publish_raw_signed_model(self):
+        # STC-21
+        validator = VirgilCardVerifier(CardCrypto())
+        if config.VIRGIL_CARD_SERVICE_PUBLIC_KEY:
+            validator._VirgilCardVerifier__virgil_public_key_base64 = config.VIRGIL_CARD_SERVICE_PUBLIC_KEY
+
+        manager = CardManager(
+            CardCrypto(),
+            api_url=config.VIRGIL_API_URL,
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            sign_callback=self.extra_sign_callback,
+            card_verifier=validator
+        )
+
+        key_pair = self._crypto.generate_keys()
+        alice_name = "alice-" + str(uuid.uuid4())
+        raw_card = manager.generate_raw_card(
+            key_pair.private_key,
+            key_pair.public_key,
+            alice_name,
+        )
+        published_card = manager.publish_card(raw_card)
+        self.assertEqual(2, len(raw_card.signatures))
+        got_card = manager.get_card(published_card.id)
+        self.assertEqual(got_card.identity, alice_name)
+        self.assertEqual(got_card.public_key, key_pair.public_key)
+        self.assertFalse(got_card.is_outdated)
 
     def test_create_card_with_invalid_previous_card_id(self):
         alice_name = "alice-" + str(uuid.uuid4())
@@ -177,6 +307,7 @@ class CardManagerTest(BaseTest):
         )
 
     def test_get_card_with_wrong_id(self):
+        # STC-34
         self.assertRaises(
             ClientException,
             self.get_card,
@@ -184,6 +315,7 @@ class CardManagerTest(BaseTest):
         )
 
     def test_search_card_with_wrong_identity(self):
+        # STC-36
         cards = self.search_card("invalid_identity")
         self.assertEqual(len(cards), 0)
 
@@ -256,6 +388,7 @@ class CardManagerTest(BaseTest):
         self.assertEqual(exported_card_json, raw_signed_model_json)
 
     def test_expired_token(self):
+        # STC-26 negative
         token_generator = JwtGenerator(
             config.VIRGIL_APP_ID,
             self._app_private_key,
@@ -281,6 +414,7 @@ class CardManagerTest(BaseTest):
         )
 
     def test_send_second_request_to_client_expired_token_retry_on_unauthorized(self):
+        # STC-26
         class FakeTokenProvider(object):
             def __init__(self, identity, token_generator, additional_token_generator=None):
                 self.identity = identity
@@ -385,11 +519,7 @@ class CardManagerTest(BaseTest):
         self.assertRaises(CardVerificationException, manager.import_card, model)
 
     def test_gets_card_with_different_id(self):
-
-        class PositiveVerifier(object):
-
-            def verify_card(self):
-                return True
+        # STC-35
 
         class FakeCardClient(object):
 
@@ -399,7 +529,7 @@ class CardManagerTest(BaseTest):
             def get_card(self, card_id, access_token):
                 return self._raw_signed_model, False
 
-        validator = PositiveVerifier()
+        validator = self.PositiveVerifier()
         key_pair = self._crypto.generate_keys()
         raw_card_content = RawCardContent(
             identity="test",
@@ -428,3 +558,139 @@ class CardManagerTest(BaseTest):
         )
         manager.card_client = FakeCardClient(model)
         self.assertRaises(CardVerificationException, manager.get_card, card_id)
+
+    def test_compatibility_import_export_card(self):
+        # STC-3
+        card_crypto = CardCrypto()
+        card_manager = CardManager(
+            card_crypto=card_crypto,
+            access_token_provider=self._data_generator.generate_empty_access_token_provider(),
+            card_verifier=self.PositiveVerifier()
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-3.as_string"])
+        card_from_json = card_manager.import_card(self._compatibility_data["STC-3.as_json"])
+
+        self.assertEqual(card_from_string.id, self._compatibility_data["STC-3.card_id"])
+        self.assertEqual(card_from_json.id, self._compatibility_data["STC-3.card_id"])
+
+        self.assertEqual(card_from_string.identity, "test")
+        self.assertEqual(card_from_json.identity, "test")
+
+        self.assertEqual(
+            card_from_string.public_key,
+            card_crypto.import_public_key(
+                bytearray(Utils.b64decode(self._compatibility_data["STC-3.public_key_base64"]))
+            )
+        )
+        self.assertEqual(
+            card_from_json.public_key,
+            card_crypto.import_public_key(
+                bytearray(Utils.b64decode(self._compatibility_data["STC-3.public_key_base64"]))
+            )
+        )
+
+        self.assertEqual(card_from_string.version, "5.0")
+        self.assertEqual(card_from_json.version, "5.0")
+
+        self.assertEqual(card_from_string.created_at, 1515686245)
+        self.assertEqual(card_from_json.created_at, 1515686245)
+
+        self.assertIsNone(card_from_string.previous_card_id)
+        self.assertIsNone(card_from_json.previous_card_id)
+
+        self.assertIsNone(card_from_string.previous_card)
+        self.assertIsNone(card_from_json.previous_card)
+
+        self.assertEqual(card_from_string.signatures, [])
+        self.assertEqual(card_from_json.signatures, [])
+
+        card_exported_string = card_manager.export_card_to_string(card_from_string)
+        self.assertEqual(self._compatibility_data["STC-3.as_string"], card_exported_string)
+
+        card_exported_json = card_manager.export_card_to_json(card_from_json)
+        self.assertEqual(card_exported_json, self._compatibility_data["STC-3.as_json"])
+
+    def test_compatibility_import_export_card_with_signature(self):
+        # STC-4
+        card_crypto = CardCrypto()
+        card_manager = CardManager(
+            card_crypto=card_crypto,
+            access_token_provider=self._data_generator.generate_empty_access_token_provider(),
+            card_verifier=self.PositiveVerifier()
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-4.as_string"])
+        card_from_json = card_manager.import_card(self._compatibility_data["STC-4.as_json"])
+
+        self.assertEqual(card_from_string.id, self._compatibility_data["STC-4.card_id"])
+        self.assertEqual(card_from_json.id, self._compatibility_data["STC-4.card_id"])
+
+        self.assertEqual(card_from_string.identity, "test")
+        self.assertEqual(card_from_json.identity, "test")
+
+        self.assertEqual(
+            card_from_string.public_key,
+            card_crypto.import_public_key(
+                bytearray(Utils.b64decode(self._compatibility_data["STC-4.public_key_base64"]))
+            )
+        )
+        self.assertEqual(
+            card_from_json.public_key,
+            card_crypto.import_public_key(
+                bytearray(Utils.b64decode(self._compatibility_data["STC-4.public_key_base64"]))
+            )
+        )
+
+        self.assertEqual(card_from_string.version, "5.0")
+        self.assertEqual(card_from_json.version, "5.0")
+
+        self.assertEqual(card_from_string.created_at, 1515686245)
+        self.assertEqual(card_from_json.created_at, 1515686245)
+
+        self.assertIsNone(card_from_string.previous_card_id)
+        self.assertIsNone(card_from_json.previous_card_id)
+
+        self.assertIsNone(card_from_string.previous_card)
+        self.assertIsNone(card_from_json.previous_card)
+
+        self.assertEqual(
+            card_from_string.signatures[0].signature,
+            b64decode(self._compatibility_data["STC-4.signature_self_base64"])
+        )
+        self.assertEqual(
+            card_from_json.signatures[0].signature,
+            b64decode(self._compatibility_data["STC-4.signature_self_base64"])
+        )
+
+        self.assertEqual(
+            card_from_string.signatures[1].signature,
+            b64decode(self._compatibility_data["STC-4.signature_virgil_base64"])
+        )
+        self.assertEqual(
+            card_from_json.signatures[1].signature,
+            b64decode(self._compatibility_data["STC-4.signature_virgil_base64"])
+        )
+
+        self.assertEqual(
+            card_from_string.signatures[2].signature,
+            b64decode(self._compatibility_data["STC-4.signature_extra_base64"])
+        )
+        self.assertEqual(
+            card_from_json.signatures[2].signature,
+            b64decode(self._compatibility_data["STC-4.signature_extra_base64"])
+        )
+
+        card_exported_string = card_manager.export_card_to_string(card_from_string)
+        self.assertEqual(self._compatibility_data["STC-4.as_string"], card_exported_string)
+
+        card_exported_json = card_manager.export_card_to_json(card_from_json)
+        self.assertEqual(card_exported_json, self._compatibility_data["STC-4.as_json"])
+
+    def extra_sign_callback(self, model):
+        key_pair = self._crypto.generate_keys()
+        model_signer = ModelSigner(CardCrypto())
+        model_signer.sign(
+            model,
+            "extra",
+            key_pair.private_key
+        )
+        return model

--- a/virgil_sdk/tests/jwt/access_token_provider_test.py
+++ b/virgil_sdk/tests/jwt/access_token_provider_test.py
@@ -33,22 +33,68 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import time
 
+from virgil_crypto.access_token_signer import AccessTokenSigner
+from virgil_sdk.tests import config
+
 from virgil_sdk.tests.base_test import BaseTest
-from virgil_sdk.jwt import TokenContext
+from virgil_sdk.jwt import TokenContext, JwtGenerator
 from virgil_sdk.jwt.providers import CachingCallbackProvider
 
 
 class CachingJwtProviderTest(BaseTest):
 
+    def __init__(self, *args, **kwargs):
+        super(CachingJwtProviderTest, self).__init__(*args, **kwargs)
+        self.renew_callback_counter = 0
+
+
     def test_return_valid_token(self):
+        # STC-38
         provider = CachingCallbackProvider(self._get_token_from_server, 10)
         jwt = provider.get_token(TokenContext("some_identity", "some_operation"))
         jwt2 = provider.get_token(TokenContext("some_identity", "some_operation"))
         self.assertEqual(jwt, jwt2)
 
     def test_return_new_token_when_expired(self):
+        # STC-38
         provider = CachingCallbackProvider(self._get_token_from_server, 1)
         jwt = provider.get_token(TokenContext("some_identity", "some_operation"))
         time.sleep(2)
         jwt2 = provider.get_token(TokenContext("some_identity", "some_operation"))
         self.assertNotEqual(jwt, jwt2)
+
+    def test_token_expiration_ttl(self):
+        # STC-40
+        key_pair = self._crypto.generate_keys()
+        jwt_generator = JwtGenerator(
+            config.VIRGIL_APP_ID,
+            key_pair.private_key,
+            config.VIRGIL_API_PUB_KEY_ID,
+            10,
+            AccessTokenSigner()
+        )
+        initial_token = jwt_generator.generate_token("initialJwt")
+        provider = CachingCallbackProvider(self.renew_jwt_callback, initial_token=initial_token, token_ttl=10)
+        self.renew_callback_counter = 0
+        context = TokenContext(identity="initialJwt", operation="test")
+        token_1 = provider.get_token(context)
+        time.sleep(3)
+        token_2 = provider.get_token(context)
+        time.sleep(9)
+        token_3 = provider.get_token(context)
+        self.assertEqual(initial_token, token_1)
+        self.assertEqual(initial_token, token_2)
+        self.assertNotEqual(initial_token, token_3)
+        self.assertEqual(1, self.renew_callback_counter)
+        self.renew_callback_counter = 0
+
+    def renew_jwt_callback(self, token_context, token_ttl):
+        builder = JwtGenerator(
+            config.VIRGIL_APP_ID,
+            self._app_private_key,
+            config.VIRGIL_API_PUB_KEY_ID,
+            token_ttl,
+            AccessTokenSigner()
+        )
+        self.renew_callback_counter += 1
+        return builder.generate_token(token_context.identity).to_string()

--- a/virgil_sdk/tests/jwt/callback_jwt_provider_test.py
+++ b/virgil_sdk/tests/jwt/callback_jwt_provider_test.py
@@ -43,6 +43,7 @@ from virgil_sdk.utils import Utils
 class AccessTokenProviderTest(BaseTest):
 
     def test_get_token_from_server(self):
+        # STC-24
         call_back_provider = CallbackJwtProvider(self._get_token_from_server)
         context = TokenContext("test_identity", "some_operation")
         token1 = call_back_provider.get_token(context)
@@ -52,6 +53,7 @@ class AccessTokenProviderTest(BaseTest):
         self.assertNotEqual(token1, token2)
 
     def test_get_invalid_token_from_server(self):
+        # STC-24
         def failed_get_from_server(context):
             return Utils.b64encode(os.urandom(30))
 
@@ -60,6 +62,7 @@ class AccessTokenProviderTest(BaseTest):
         self.assertRaises(ValueError, callback_provider.get_token, context)
 
     def test_get_const_access_token(self):
+        # STC-37
         token_from_server = self._get_token_from_server(
             TokenContext(
                 Utils.b64encode(os.urandom(20)),

--- a/virgil_sdk/tests/jwt/jwt_verifier_test.py
+++ b/virgil_sdk/tests/jwt/jwt_verifier_test.py
@@ -35,7 +35,7 @@ from virgil_sdk.tests import config
 from virgil_sdk.tests import BaseTest
 
 from virgil_crypto.access_token_signer import AccessTokenSigner
-from virgil_sdk.jwt import Jwt, JwtVerifier
+from virgil_sdk.jwt import Jwt, JwtVerifier, JwtGenerator
 from virgil_sdk.utils import Utils
 
 
@@ -74,3 +74,124 @@ class JwtVerifierTest(BaseTest):
         )
         self.assertEqual(exported_token, token_base64)
         self.assertTrue(verifier.verify_token(jwt))
+
+    def test_verify_generated_jwt(self):
+        # STC-23
+        public_key_base64 = self._compatibility_data["STC-23.api_public_key_base64"]
+        private_key_base64 = self._compatibility_data["STC-23.api_private_key_base64"]
+        private_key = self._crypto.import_private_key(Utils.strtobytes(Utils.b64decode(private_key_base64)))
+        public_key = self._crypto.import_public_key(Utils.strtobytes(Utils.b64decode(public_key_base64)))
+        key_id_base64 = self._compatibility_data["STC-23.api_key_id"]
+        signer = AccessTokenSigner()
+
+        jwt_generator = JwtGenerator(
+            self._compatibility_data["STC-23.app_id"],
+            private_key,
+            key_id_base64,
+            10,
+            signer
+        )
+        token = jwt_generator.generate_token("some_identity", data={"username": "some_username"})
+        verifier = JwtVerifier(
+            signer,
+            public_key,
+            key_id_base64
+        )
+        self.assertFalse(token.is_expired())
+        self.assertTrue(verifier.verify_token(token))
+
+    def test_verify_imported_compatibility_jwt(self):
+        # STC-28
+        token_base64 = self._compatibility_data["STC-28.jwt"]
+        jwt = Jwt.from_string(token_base64)
+        self.assertEqual(self._compatibility_data["STC-28.jwt_identity"], jwt.body_content.identity)
+        self.assertEqual(self._compatibility_data["STC-28.jwt_app_id"], jwt.body_content.app_id)
+        self.assertEqual(self._compatibility_data["STC-28.jw_issuer"], jwt.body_content.issuer)
+        self.assertEqual(self._compatibility_data["STC-28.jwt_subject"], jwt.body_content.subject)
+        self.assertEqual(
+            Utils.json_loads(self._compatibility_data["STC-28.jwt_additional_data"]),
+            jwt.body_content.additional_data
+        )
+        self.assertEqual(
+            int(self._compatibility_data["STC-28.jwt_expires_at"]),
+            jwt.body_content.expires_at_timestamp
+        )
+        self.assertEqual(
+            int(self._compatibility_data["STC-28.jwt_issued_at"]),
+            jwt.body_content.issued_at_timestamp
+        )
+        self.assertEqual(self._compatibility_data["STC-28.jwt_algorithm"], jwt.header_content.algorithm)
+        self.assertEqual(self._compatibility_data["STC-28.jwt_api_key_id"], jwt.header_content.key_id)
+        self.assertEqual(self._compatibility_data["STC-28.jwt_content_type"], jwt.header_content.content_type)
+        self.assertEqual(self._compatibility_data["STC-28.jwt_type"], jwt.header_content.access_token_type)
+        self.assertEqual(
+            Utils.b64decode(self._compatibility_data["STC-28.jwt_signature_base64"]),
+            jwt.signature_data
+        )
+        self.assertTrue(jwt.is_expired())
+        self.assertEqual(token_base64, jwt.to_string())
+
+    def test_verify_imported_compatibility_jwt_not_expired(self):
+        # STC-29
+        token_base64 = self._compatibility_data["STC-29.jwt"]
+        jwt = Jwt.from_string(token_base64)
+        self.assertEqual(self._compatibility_data["STC-29.jwt_identity"], jwt.body_content.identity)
+        self.assertEqual(self._compatibility_data["STC-29.jwt_app_id"], jwt.body_content.app_id)
+        self.assertEqual(self._compatibility_data["STC-29.jw_issuer"], jwt.body_content.issuer)
+        self.assertEqual(self._compatibility_data["STC-29.jwt_subject"], jwt.body_content.subject)
+        self.assertEqual(
+            Utils.json_loads(self._compatibility_data["STC-29.jwt_additional_data"]),
+            jwt.body_content.additional_data
+        )
+        self.assertEqual(
+            int(self._compatibility_data["STC-29.jwt_expires_at"]),
+            jwt.body_content.expires_at_timestamp
+        )
+        self.assertEqual(
+            int(self._compatibility_data["STC-29.jwt_issued_at"]),
+            jwt.body_content.issued_at_timestamp
+        )
+        self.assertEqual(self._compatibility_data["STC-29.jwt_algorithm"], jwt.header_content.algorithm)
+        self.assertEqual(self._compatibility_data["STC-29.jwt_api_key_id"], jwt.header_content.key_id)
+        self.assertEqual(self._compatibility_data["STC-29.jwt_content_type"], jwt.header_content.content_type)
+        self.assertEqual(self._compatibility_data["STC-29.jwt_type"], jwt.header_content.access_token_type)
+        self.assertEqual(
+            Utils.b64decode(self._compatibility_data["STC-29.jwt_signature_base64"]),
+            jwt.signature_data
+        )
+        self.assertFalse(jwt.is_expired())
+        self.assertEqual(token_base64, jwt.to_string())
+
+    def test_generate_token_with_wrong_additional_data_type(self):
+        key_pair = self._crypto.generate_keys()
+        api_public_key_id = config.VIRGIL_API_PUB_KEY_ID
+        app_id = config.VIRGIL_APP_ID
+        signer = AccessTokenSigner()
+
+        jwt_generator = JwtGenerator(
+            app_id,
+            key_pair.private_key,
+            api_public_key_id,
+            60,
+            signer
+        )
+        # try init with string
+        self.assertRaises(
+            TypeError,
+            jwt_generator.generate_token,
+            "some_username",
+            "some text"
+
+        )
+        self.assertRaises(
+            TypeError,
+            jwt_generator.generate_token,
+            "some_username",
+            ["some text", "another text"]
+        )
+        self.assertRaises(
+            TypeError,
+            jwt_generator.generate_token,
+            "some_username",
+            ("some text", "another text")
+        )

--- a/virgil_sdk/tests/storage/key_storage_test.py
+++ b/virgil_sdk/tests/storage/key_storage_test.py
@@ -44,6 +44,7 @@ from virgil_sdk.tests import BaseTest
 class KeyStorageTest(BaseTest):
 
     def test_store(self):
+        # STC-5, STC-6
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
         key_entry = KeyEntry(
@@ -60,11 +61,13 @@ class KeyStorageTest(BaseTest):
             os.remove(file_path)
 
     def test_store_none(self):
+        # STC-5, STC-6
         key_entry = None
         key_storage = KeyStorage()
         self.assertRaises(ValueError, key_storage.store, key_entry)
 
     def test_load(self):
+        # STC-5, STC-6
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         additional_data = {"some_key": "some_value"}
         key_pair = self._crypto.generate_keys()
@@ -84,15 +87,18 @@ class KeyStorageTest(BaseTest):
             os.remove(self.__filename_for_clean(key_storage, key_name))
 
     def test_load_unexisting_key(self):
+        # STC-5, STC-6
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(10)).decode()))
         key_storage = KeyStorage()
         self.assertRaises(ValueError, key_storage.load, key_name)
 
     def test_load_key_with_empty_name(self):
+        # STC-5, STC-6
         key_storage = KeyStorage()
         self.assertRaises(ValueError, key_storage.load, None)
 
     def test_delete(self):
+        # STC-5, STC-6
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
         key_entry = KeyEntry(
@@ -112,11 +118,13 @@ class KeyStorageTest(BaseTest):
                 os.remove(file_path)
 
     def test_delete_unexisting_key(self):
+        # STC-5, STC-6
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(10)).decode()))
         key_storage = KeyStorage()
         self.assertRaises(ValueError, key_storage.delete, key_name)
 
     def test_delete_key_empty_name(self):
+        # STC-5, STC-6
         key_storage = KeyStorage()
         self.assertRaises(ValueError, key_storage.delete, None)
 

--- a/virgil_sdk/tests/storage/private_key_storage_test.py
+++ b/virgil_sdk/tests/storage/private_key_storage_test.py
@@ -43,6 +43,7 @@ from virgil_sdk.tests import BaseTest
 class PrivateKeyStorageTest(BaseTest):
 
     def test_store(self):
+        # STC-7
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
         private_key_exporter = PrivateKeyExporter(self._crypto)
@@ -54,18 +55,21 @@ class PrivateKeyStorageTest(BaseTest):
             os.remove(self.__filename_for_clean(private_key_storage, key_name))
 
     def test_store_empty_name(self):
+        # STC-7
         key_pair = self._crypto.generate_keys()
         private_key_exporter = PrivateKeyExporter(self._crypto)
         private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.store, key_pair.private_key, None)
 
     def test_store_empty_key(self):
+        # STC-7
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         private_key_exporter = PrivateKeyExporter(self._crypto)
         private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.store, None, key_name)
 
     def test_load(self):
+        # STC-7
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
         additional_data = {"some_key": "some_val"}
@@ -80,12 +84,14 @@ class PrivateKeyStorageTest(BaseTest):
             os.remove(self.__filename_for_clean(private_key_storage, key_name))
 
     def test_load_unexisting_key(self):
+        # STC-7
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(10)).decode()))
         private_key_exporter = PrivateKeyExporter(self._crypto)
         private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.load, key_name)
 
     def test_delete(self):
+        # STC-7
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(5)).decode()))
         key_pair = self._crypto.generate_keys()
         private_key_exporter = PrivateKeyExporter(self._crypto)
@@ -99,12 +105,14 @@ class PrivateKeyStorageTest(BaseTest):
                 os.remove(self.__filename_for_clean(private_key_storage, key_name))
 
     def test_delete_unexisting_key(self):
+        # STC-7
         key_name = "test_key-{}".format(str(binascii.hexlify(os.urandom(10)).decode()))
         private_key_exporter = PrivateKeyExporter(self._crypto)
         private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.delete, key_name)
 
     def test_delete_empty_name(self):
+        # STC-7
         private_key_exporter = PrivateKeyExporter(self._crypto)
         private_key_storage = PrivateKeyStorage(private_key_exporter)
         self.assertRaises(ValueError, private_key_storage.delete, None)

--- a/virgil_sdk/tests/verification/card_verifier_test.py
+++ b/virgil_sdk/tests/verification/card_verifier_test.py
@@ -1,0 +1,233 @@
+# Copyright (C) 2016-2018 Virgil Security Inc.
+#
+# Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     (1) Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#     (2) Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#     (3) Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from virgil_crypto.card_crypto import CardCrypto
+
+from virgil_sdk import CardManager, VirgilCardVerifier
+from virgil_sdk.jwt.providers import CallbackJwtProvider
+from virgil_sdk.tests import BaseTest
+from virgil_sdk.utils import Utils
+from virgil_sdk.verification import WhiteList, VerifierCredentials
+
+
+class CardVerifierTest(BaseTest):
+
+    def test_compatibilty_card_verification_white_lists(self):
+        # STC-10
+        validator = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_verifier = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_manager = CardManager(
+            card_crypto=CardCrypto(),
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            card_verifier=validator,
+            sign_callback=self.sign_callback
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-10.as_string"])
+        private_key_1 = self._crypto.import_private_key(
+            bytearray(Utils.b64decode(self._compatibility_data["STC-10.private_key1_base64"]))
+        )
+        public_key_1 = self._crypto.extract_public_key(private_key_1)
+        public_key_1_base64 = Utils.b64encode(self._crypto.export_public_key(public_key_1))
+
+        key_pair_2 = self._crypto.generate_keys()
+        public_key_2_base64 = Utils.b64encode(self._crypto.export_public_key(key_pair_2.public_key))
+
+        key_pair_3 = self._crypto.generate_keys()
+        public_key_3_base64 = Utils.b64encode(self._crypto.export_public_key(key_pair_3.public_key))
+
+        self.assertTrue(card_verifier.verify_card(card_from_string))
+
+        card_verifier.verify_self_signature = True
+        self.assertTrue(card_verifier.verify_card(card_from_string))
+
+        card_verifier.verify_virgil_signature = True
+        self.assertTrue(card_verifier.verify_card(card_from_string))
+
+        creds_1 = VerifierCredentials(signer="extra", public_key_base64=public_key_1_base64)
+        white_list_1 = WhiteList(creds_1)
+        card_verifier.white_lists = [white_list_1]
+        self.assertTrue(card_verifier.verify_card(card_from_string))
+
+        creds_2_1 = VerifierCredentials(signer="extra", public_key_base64=public_key_1_base64)
+        creds_2_2 = VerifierCredentials(signer="test1", public_key_base64=public_key_2_base64)
+        white_list_2 = WhiteList([creds_2_1, creds_2_2])
+        card_verifier.white_lists = [white_list_2]
+        self.assertTrue(card_verifier.verify_card(card_from_string))
+
+        creds_3_1 = VerifierCredentials(signer="extra", public_key_base64=public_key_1_base64)
+        creds_3_2 = VerifierCredentials(signer="test1", public_key_base64=public_key_2_base64)
+        creds_3_3 = VerifierCredentials(signer="test1", public_key_base64=public_key_3_base64)
+        white_list_3_1 = WhiteList([creds_3_1, creds_3_2])
+        white_list_3_2 = WhiteList(creds_3_3)
+        card_verifier.white_lists = [white_list_3_1, white_list_3_2]
+        self.assertFalse(card_verifier.verify_card(card_from_string))
+
+    def test_compatibilty_card_verification_self_sign_failed(self):
+        # STC-11
+        validator = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_verifier = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_manager = CardManager(
+            card_crypto=CardCrypto(),
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            card_verifier=validator,
+            sign_callback=self.sign_callback
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-11.as_string"])
+        self.assertTrue(card_verifier.verify_card(card_from_string))
+        card_verifier.verify_self_signature = True
+        self.assertFalse(card_verifier.verify_card(card_from_string))
+
+    def test_compatibilty_card_verification_virgil_sign_failed(self):
+        # STC-12
+        validator = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_verifier = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_manager = CardManager(
+            card_crypto=CardCrypto(),
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            card_verifier=validator,
+            sign_callback=self.sign_callback
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-12.as_string"])
+        self.assertTrue(card_verifier.verify_card(card_from_string))
+        card_verifier.verify_virgil_signature = True
+        self.assertFalse(card_verifier.verify_card(card_from_string))
+
+    def test_compatibilty_card_verification_virgil_sign_failed_2(self):
+        # STC-14
+        validator = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_verifier = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=True,
+            white_lists=[]
+        )
+        card_manager = CardManager(
+            card_crypto=CardCrypto(),
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            card_verifier=validator,
+            sign_callback=self.sign_callback
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-14.as_string"])
+        self.assertFalse(card_verifier.verify_card(card_from_string))
+
+    def test_compatibilty_card_verification_self_sign_failed_2(self):
+        # STC-15
+        validator = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_verifier = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=True,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_manager = CardManager(
+            card_crypto=CardCrypto(),
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            card_verifier=validator,
+            sign_callback=self.sign_callback
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-15.as_string"])
+        self.assertFalse(card_verifier.verify_card(card_from_string))
+
+    def test_compatibilty_card_verification_invalid_custom_sign(self):
+        # STC-16
+        validator = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_verifier = VirgilCardVerifier(
+            CardCrypto(),
+            verify_self_signature=False,
+            verify_virgil_signature=False,
+            white_lists=[]
+        )
+        card_manager = CardManager(
+            card_crypto=CardCrypto(),
+            access_token_provider=CallbackJwtProvider(self._get_token_from_server),
+            card_verifier=validator,
+            sign_callback=self.sign_callback
+        )
+        card_from_string = card_manager.import_card(self._compatibility_data["STC-16.as_string"])
+        public_key_1_base64 = self._compatibility_data["STC-16.public_key1_base64"]
+        key_pair_2 = self._crypto.generate_keys()
+        public_key_2_base64 = Utils.b64encode(self._crypto.export_public_key(key_pair_2.public_key))
+
+        creds_1 = VerifierCredentials(signer="extra", public_key_base64=public_key_2_base64)
+        card_verifier.white_lists = [WhiteList(creds_1)]
+        self.assertFalse(card_verifier.verify_card(card_from_string))
+
+        creds_2 = VerifierCredentials(signer="extra", public_key_base64=public_key_1_base64)
+        card_verifier.white_lists = WhiteList(creds_2)
+        self.assertTrue(card_verifier.verify_card(card_from_string))

--- a/virgil_sdk/utils/utils.py
+++ b/virgil_sdk/utils/utils.py
@@ -74,7 +74,7 @@ class Utils(object):
         except (binascii.Error, TypeError) as e:
             missing_padding = len(source) % 4
             if missing_padding != 0:
-                if isinstance(source, str) or isinstance(source, unicode):
+                if isinstance(source, str) or check_unicode(source):
                     source += '=' * (4 - missing_padding)
                 if isinstance(source, bytes) or isinstance(source, bytearray):
                     source += b'=' * (4 - missing_padding)

--- a/virgil_sdk/verification/virgil_card_verifier.py
+++ b/virgil_sdk/verification/virgil_card_verifier.py
@@ -47,7 +47,7 @@ class VirgilCardVerifier(CardVerifier):
         crypto,
         verify_self_signature=True,  # type: bool
         verify_virgil_signature=True,  # type: bool
-        white_lists=list()  # type: list
+        white_lists=list()  # type: List[WhiteList]
     ):
         self._crypto = crypto
         self.verify_self_signature = verify_self_signature
@@ -91,8 +91,6 @@ class VirgilCardVerifier(CardVerifier):
         verifiers_credentials_lists = list(map(lambda x: x.verifiers_credentials, self.white_lists))
 
         for verifiers_credentials in verifiers_credentials_lists:
-            if not verifiers_credentials or any(verifiers_credentials):
-                return False
 
             intersected_creds = list(filter(lambda x: x.signer in signers, verifiers_credentials))
 
@@ -126,7 +124,7 @@ class VirgilCardVerifier(CardVerifier):
                 extended_snapshot = bytearray(Utils.b64_decode(card.content_snapshot))
 
             if self._crypto.verify_signature(
-                bytearray(Utils.b64_decode(signature.signature)),
+                bytearray(signature.signature),
                 extended_snapshot,
                 signer_public_key
             ):
@@ -142,4 +140,7 @@ class VirgilCardVerifier(CardVerifier):
     def white_lists(self, value):
         if value:
             self.__white_lists = list()
-            self.__white_lists += value
+            if not isinstance(value, list):
+                self.__white_lists += [value]
+            else:
+                self.__white_lists += value

--- a/virgil_sdk/verification/white_list.py
+++ b/virgil_sdk/verification/white_list.py
@@ -37,8 +37,14 @@ class WhiteList(object):
     """The Whitelist implements a collection of VerifierCredentials
     that is used for card verification in VirgilCardVerifier."""
 
-    def __init__(self):
-        self.__verifiers_credentials = list()
+    def __init__(self, verifier_credentials=None):
+        # type: (Union[List[VerifierCredentials], VerifierCredentaials])->None
+        if verifier_credentials is None:
+            self.__verifiers_credentials = list()
+        if isinstance(verifier_credentials, list):
+            self.__verifiers_credentials = verifier_credentials
+        else:
+            self.__verifiers_credentials = [verifier_credentials]
 
     @property
     def verifiers_credentials(self):


### PR DESCRIPTION
Fix card creation signed model
Fix card validation after search
Fix issue with sign_callback
Fix CardSignature to_json method
Add CachingCallbackProvider new parameter for an initial access token
Change few properties of Jwt from protected to public
Fix issue with additional data parse in Jwt
Add alerts when user try to instantiate Jwt with data argument different from a dictionary
Add a lot of test cases